### PR TITLE
Remove abstract from Component

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -97,7 +97,6 @@ class Component(models.Model):
     index = models.IntegerField()
 
     class Meta:
-        abstract = True
         ordering = ['index']
 
     def __str__(self):


### PR DESCRIPTION
#6 

Right now we can't query for all components in the database since we defined `Component` as abstract

https://stackoverflow.com/a/3798211
https://godjango.com/blog/django-abstract-base-class-multi-table-inheritance/