### PR TITLE
Restrict user access

### DIFF
--- a/ICE/urls.py
+++ b/ICE/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
     path('accounts/signup/', signup, name='signup'),
     path('admin/', admin.site.urls),
     path('admin/invite', invite, name='invite'),
+    path('admin/restrict', restrict_access, name='restrict_access'),
     path('courses/', include('courses.urls')),
 ]
 

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -27,3 +27,9 @@ class InstructorRegisterForm(UserCreationForm):
     class Meta:
         model = User
         fields = ('username', 'first_name', 'last_name', 'password1', 'password2', 'autobiography')
+
+class RestrictUserForm(forms.Form):
+    username = forms.ModelChoiceField(queryset=User.objects.filter(is_active=True, is_superuser=False).order_by('username'))
+
+class UnrestrictUserForm(forms.Form):
+    username = forms.ModelChoiceField(queryset=User.objects.filter(is_active=False, is_superuser=False).order_by('username')) 

--- a/templates/admin/restrict_user.html
+++ b/templates/admin/restrict_user.html
@@ -1,0 +1,14 @@
+{% block content %}
+  <h2>Restrict users's access</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ restrict_user_form }}
+    <button type="submit">Submit</button>
+  </form>
+  <h2>Unrestrict user's access</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ unrestrict_user_form }}
+    <button type="submit">Submit</button>
+  </form>
+{% endblock %} 


### PR DESCRIPTION
Restricted users' account by setting the is_active attribute to False, such that the user will not be able to login.

Also, for the functionality of restricting create/modify modules/components etc to Instructor, the proper way to implement that seems to be using Django's permission features such that we won't need the Instructor and Learner class for classifying user types. However, as we have already implemented them, I think sticking to our approach of having user identifiers will be better.